### PR TITLE
Change O(n) to O(1)

### DIFF
--- a/3_advanced/chapter15/examples/running_time.py
+++ b/3_advanced/chapter15/examples/running_time.py
@@ -29,4 +29,4 @@ for number in [123, 4, 21, 312, 41]:  # O(n)
 example_list = [12, 3, 214, 5, 12]
 for num1 in example_list:  # O(n)
     for num2 in example_list:  # O(n)
-        print(num1, num2)  # O(n)
+        print(num1, num2)  # O(1)


### PR DESCRIPTION
print(num1, num2)  was commented as O(n), but I think it just takes O(1) to execute. I could also just be wrong.

Update running_time.py